### PR TITLE
Added GitHub Action for Lint checking with Black.

### DIFF
--- a/.github/.workflows/black-lint-check.yml
+++ b/.github/.workflows/black-lint-check.yml
@@ -5,7 +5,12 @@ on: [push, pull_request]
 jobs:
   lint-black:
     runs-on: ubuntu-latest
+    - name: Run lint check with Black
     steps:
     - uses: actions/checkout@v2
+    - name: Install Black
     - run: pip install black
+    - name: Check Black version
+    - run: black --version 
+    - name : Check formatting of files 
     - run: black --check .


### PR DESCRIPTION
This PR adds lint checking with Black as a GitHub action.

As a consequence, any changes to `.py` files will now be checked if they follow proper Black formatting policies. If they don't, this GitHub action will fail.